### PR TITLE
Handle Emulator Names with Spaces

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -64,6 +64,13 @@ else
   commandLineToolsDownloadUrlPattern="https:\/\/dl.google.com\/android\/repository\/sdk\-tools\-linux\-[0-9]*\.zip"
 fi
 
+# After the emulator indicates that it has booted, it may take a
+# bit more time before the launcher shows and the device is ready
+# for interaction. This number configures how many seconds to wait
+# after the device indicates that it is ready before proceeding to
+# interact with it.
+emulatorBootedSleepTime=30
+
 # Regex used to locate the latest version of JDK 8 available
 # from SDKMan. More info on versions here: https://bit.ly/2SCGEnb
 jdkPattern="8\.0\.[0-9][0-9][0-9]\.hs\-adpt"

--- a/emulator/create-avd.sh
+++ b/emulator/create-avd.sh
@@ -22,7 +22,7 @@ fi
 
 echo "Obtaining image: $imageName"
 (for run in {1..$sdkManagerWaitTime}; do sleep 1; echo y 2>/dev/null; done) | sdkmanager $imageName >> /dev/null
-echo "Created!"
+echo "Obtained"
 
 echo "Accepting any remaining licenses"
 (for run in {1..$sdkManagerWaitTime}; do sleep 1; echo y 2>/dev/null; done) | sdkmanager --licenses
@@ -33,9 +33,9 @@ echo "Creating AVD: $emulatorDeviceName"
 
 avdmanager create avd \
   --abi google_apis/x86 \
-  --device $deviceProfile \
+  --device "$deviceProfile" \
   --force \
-  --name $emulatorDeviceName \
+  --name "$emulatorDeviceName" \
   --package $imageName
 
-echo "AVD create"
+echo "AVD created"

--- a/emulator/start-emulator.sh
+++ b/emulator/start-emulator.sh
@@ -35,5 +35,6 @@ until [[ "$animationState" =~ "stopped" ]]; do
     sleep 1
 done
 
+echo "Waiting for launcher to show..."
+sleep $emulatorBootedSleepTime
 echo "Emulator is ready!"
-sleep 30

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -3,3 +3,9 @@
 currentDirController="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$currentDirController/setup-host.sh"
 source "$currentDirController/setup-emulator.sh"
+
+echo 
+echo "*******************************************************"
+echo "**************** You are ready to go! *****************"
+echo "*******************************************************"
+echo 

--- a/setup-emulator.sh
+++ b/setup-emulator.sh
@@ -16,3 +16,9 @@ source "$currentDirController/emulator/fix-gboard.sh"
 source "$currentDirController/emulator/fix-google-chrome.sh"
 source "$currentDirController/emulator/fix-google-maps.sh"
 source "$currentDirController/emulator/fix-webview-shell.sh"
+
+echo 
+echo "*******************************************************"
+echo "******** Finished setting up Android emulator! ********"
+echo "*******************************************************"
+echo 

--- a/setup-emulator.sh
+++ b/setup-emulator.sh
@@ -4,7 +4,7 @@ currentDirController="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 &
 source "$currentDirController/config.sh"
 source "$installDestination/paths.sh"
 
-alreadyHasAvd=$(emulator -list-avds | grep -o "$emulatorDeviceName")
+alreadyHasAvd=$($installDestination/emulator/emulator -list-avds | grep -o "$emulatorDeviceName")
 
 # Don't bother setting up the AVD again, if already done
 if [[ "$alreadyHasAvd" == "" ]]; then

--- a/setup-host.sh
+++ b/setup-host.sh
@@ -8,3 +8,9 @@ source "$currentDirController/host/install-java.sh"
 source "$currentDirController/host/create-paths.sh"
 source "$currentDirController/host/install-paths.sh"
 source "$currentDirController/host/install-android-sdk.sh"
+
+echo 
+echo "*******************************************************"
+echo "************ Finished setting up the host! ************"
+echo "*******************************************************"
+echo 


### PR DESCRIPTION
It turns out that emulator names and device profiles with spaces, such as "Nexus 6P", cause the AVD creation process to break. Those arguments should be surrounded by quotes.